### PR TITLE
Fix to not capture all dom events

### DIFF
--- a/src/theta-viewer.coffee
+++ b/src/theta-viewer.coffee
@@ -14,7 +14,7 @@ class ThetaViewer
     @renderer.setSize @width, @height
     @dom.appendChild @renderer.domElement
 
-    @controls = new THREE.OrbitControls @camera
+    @controls = new THREE.OrbitControls @camera @dom
 
     @controls.addEventListener 'change', =>
       @renderer.render @scene, @camera


### PR DESCRIPTION
Pass the correct dom element, by default even u have a small div on the page, it will capture all page events. This does not allow scrolling on a page with this viewer on for example.